### PR TITLE
fix: Changed the order of the workflow's steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,11 +37,6 @@ jobs:
         with:
           name: code-coverage-results
           path: coverage
-      - name: ZIP Assets
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          zip -r build.zip ./build     
-          zip -r coverage.zip ./coverage
 
       # These steps will run only if the triggering event is the "push" event, which in reallity happens when you merge the
       # workflow branch into the develop branch
@@ -54,6 +49,13 @@ jobs:
         with:
           name: built-project
           path: build
+
+      - name: ZIP Assets
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          zip -r build.zip ./build     
+          zip -r coverage.zip ./coverage
+
       # Create a release using the 'semantic-release' library
       - name: Create a Release
         # Here we make sure that we only run this step when the push is being made to 'main' branch


### PR DESCRIPTION
The ZIP command was being triggered before the project was built, so the command was throwing an error